### PR TITLE
docs: stale branch review — 3 branches pending Nathan's decision

### DIFF
--- a/docs/reports/STALE_BRANCHES_REVIEW-2026-06-16.md
+++ b/docs/reports/STALE_BRANCHES_REVIEW-2026-06-16.md
@@ -1,0 +1,98 @@
+# Stale Branch Review — 2026-06-16
+
+**Reviewed by:** Automated Estate Steward
+**Status:** All 3 branches are **NOT merged** into `main` — flagged for Nathan's decision.
+
+---
+
+## Branch Summaries
+
+### 1. `auto/commit-uncommitted-changes-in-transcript`
+
+| Field | Detail |
+|-------|--------|
+| Created | 2026-05-08 |
+| Age | ~39 days |
+| Unique commits | 1 |
+| Content type | **Functional change** |
+
+**Change:** `fix(deps): remove peer dependency flags from package-lock.json`
+Removes `"peer": true` from 3 entries in `package-lock.json`:
+- `@redis/client` v1.6.1
+- `@typescript-eslint/parser` v6.21.0
+- `eslint` v8.15.0
+
+**Assessment:** Low-risk cosmetic fix to `package-lock.json`. Does not change installed versions. Could be merged or discarded with no production impact either way.
+
+**Recommendation:** Review and merge OR delete.
+
+---
+
+### 2. `auto/clean-up-1-stale-branch-in-transcription`
+
+| Field | Detail |
+|-------|--------|
+| Created | 2026-05-16 |
+| Age | ~31 days |
+| Unique commits | 1 |
+| Content type | **Docs only** |
+
+**Change:** Added `STALE_BRANCH_REVIEW.md` to repo root flagging `auto/commit-uncommitted-changes-in-transcript` for Nathan's review.
+
+**Assessment:** Previous automated cleanup task. Its only content is a review report that was never acted upon. The referenced branch still exists unmerged. This branch has no functional value.
+
+**Recommendation:** Safe to delete (docs-only artifact, superseded by this report).
+
+---
+
+### 3. `auto/clean-up-2-stale-branches-in-transcripti`
+
+| Field | Detail |
+|-------|--------|
+| Created | 2026-05-27 |
+| Age | ~20 days |
+| Unique commits | 1 |
+| Content type | **Docs only** |
+
+**Change:** Added `docs/reports/STALE_BRANCHES_REVIEW-2026-05-27.md` flagging 2 branches for Nathan's review.
+
+**Assessment:** Another previous automated cleanup task. Docs-only, superseded by this report.
+
+**Recommendation:** Safe to delete (docs-only artifact, superseded by this report).
+
+---
+
+## Action Required from Nathan
+
+| Branch | Decision |
+|--------|----------|
+| `auto/commit-uncommitted-changes-in-transcript` | Merge the package-lock.json fix, or delete if not needed |
+| `auto/clean-up-1-stale-branch-in-transcription` | Delete — docs-only, no functional value |
+| `auto/clean-up-2-stale-branches-in-transcripti` | Delete — docs-only, no functional value |
+
+### To delete the docs-only branches
+
+```bash
+git branch -D auto/clean-up-1-stale-branch-in-transcription
+git push origin --delete auto/clean-up-1-stale-branch-in-transcription
+
+git branch -D auto/clean-up-2-stale-branches-in-transcripti
+git push origin --delete auto/clean-up-2-stale-branches-in-transcripti
+```
+
+### To merge the package-lock.json fix
+
+```bash
+git checkout main
+git merge auto/commit-uncommitted-changes-in-transcript
+git push origin main
+git branch -D auto/commit-uncommitted-changes-in-transcript
+git push origin --delete auto/commit-uncommitted-changes-in-transcript
+```
+
+### To discard the package-lock.json fix
+
+```bash
+git branch -D auto/commit-uncommitted-changes-in-transcript
+git push origin --delete auto/commit-uncommitted-changes-in-transcript
+```


### PR DESCRIPTION
## Summary

All 3 stale branches have been reviewed against `main`. None are merged.

| Branch | Age | Content | Recommendation |
|--------|-----|---------|----------------|
| `auto/commit-uncommitted-changes-in-transcript` | ~39 days | package-lock.json fix (functional) | Merge or delete |
| `auto/clean-up-1-stale-branch-in-transcription` | ~31 days | Docs-only review report | Delete |
| `auto/clean-up-2-stale-branches-in-transcripti` | ~20 days | Docs-only review report | Delete |

See `docs/reports/STALE_BRANCHES_REVIEW-2026-06-16.md` for full details and ready-to-run deletion commands.

## No automated deletions were made

The two docs-only branches are safe to delete with no data loss. The functional branch (`auto/commit-uncommitted-changes-in-transcript`) needs Nathan's review before action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)